### PR TITLE
fix to execute command with multiple options

### DIFF
--- a/bin/runonce
+++ b/bin/runonce
@@ -39,8 +39,8 @@ shift $((OPTIND-1))
 if [[ "X" == "X$@" ]]; then
     help_and_exit 1
 fi
-
-lock="$HOME/.runonce-$(basename $@)"
+MYBASENAME="$@"
+lock="$HOME/.runonce-$(echo -n $MYBASENAME|md5sum|cut -d" " -f1)"
 if [[ ! -e $lock ]]; then
     "$@"
     touch $lock


### PR DESCRIPTION
example: runone -i 1440 /usr/local/bin/curator_cli --timeout 3600 snapshot --repository repo--wait_for_completion true --name "snap_%Y%m%d%" --filter_list '[{"filtertype":"pattern","kind":"prefix","value":"value_","exclude":"True"},{"filtertype":"age","source":"name","direction":"younger","timestring":"%Y.%m.%d","unit":"days","unit_count":"100"}]'